### PR TITLE
Apply GitHub styling and cybersecurity content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # vscode-portfolio
 [![Open is Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/itsnitinr/vscode-portfolio)
 
-A Visual Studio Code themed developer portfolio website built with Next.js and deployed on Vercel.
+A GitHub inspired portfolio website built with Next.js. This fork showcases a cybersecurity student profile.
 
 ![vscode-portfolio banner](https://imgur.com/JXJ9mpO.gif)
+
+This version mimics GitHub's dark theme and contains sample content for a cybersecurity student named **Alex Cyber**.
 
 ## Features Roadmap
 

--- a/components/ContactCode.tsx
+++ b/components/ContactCode.tsx
@@ -3,38 +3,28 @@ import styles from '@/styles/ContactCode.module.css';
 const contactItems = [
   {
     social: 'website',
-    link: 'nitinranganath.com',
-    href: 'https://nitinranganath.com',
+    link: 'alexcyber.dev',
+    href: 'https://alexcyber.dev',
   },
   {
     social: 'email',
-    link: 'nitinranganath@gmail.com',
-    href: 'mailto:nitinranganath@gmail.com',
+    link: 'alex@cyber.dev',
+    href: 'mailto:alex@cyber.dev',
   },
   {
     social: 'github',
-    link: 'itsnitinr',
-    href: 'https://github.com/itsnitinr',
+    link: 'alexcyber',
+    href: 'https://github.com/alexcyber',
   },
   {
     social: 'linkedin',
-    link: 'nitinranganath',
-    href: 'https://www.linkedin.com/in/nitinranganath/',
+    link: 'alexcyber',
+    href: 'https://www.linkedin.com/in/alexcyber/',
   },
   {
     social: 'twitter',
-    link: 'iamnitinr',
-    href: 'https://www.twitter.com/iamnitinr',
-  },
-  {
-    social: 'telegram',
-    link: 'iamnitinr',
-    href: 'https://t.me/iamnitinr',
-  },
-  {
-    social: 'peerlist',
-    link: 'nitinranganath',
-    href: 'https://peerlist.io/nitinranganath',
+    link: 'alex_cyber',
+    href: 'https://twitter.com/alex_cyber',
   },
 ];
 

--- a/data/projects.ts
+++ b/data/projects.ts
@@ -8,35 +8,35 @@ export interface Project {
 
 export const projects: Project[] = [
   {
-    title: 'Driwwwle',
+    title: 'CTF Toolkit',
     description:
-      'Discover creative websites and developers. A portal for you to share your projects.',
-    logo: '/logos/driwwwle.svg',
-    link: 'https://github.com/itsnitinr/driwwwle',
-    slug: 'driwwwle',
-  },
-  {
-    title: 'VSCode Portfolio',
-    description:
-      'A Visual Studio Code themed developer portfolio built with Next.js and CSS Modules.',
+      'Collection of utilities and scripts to speed up Capture The Flag challenges.',
     logo: '/logos/vsc.svg',
-    link: 'https://github.com/itsnitinr/vscode-portfolio',
-    slug: 'vscode-portfolio',
+    link: 'https://github.com/alexcyber/ctf-toolkit',
+    slug: 'ctf-toolkit',
   },
   {
-    title: 'Subtrackt',
+    title: 'Secure Chat',
     description:
-      'A simple and elegant way to track your subscriptions and save money.',
-    logo: '/logos/subtrackt.svg',
-    link: 'https://github.com/itsnitinr/subtrackt',
-    slug: 'subtrackt',
+      'End-to-end encrypted chat application built with Node.js and React.',
+    logo: '/logos/react_icon.svg',
+    link: 'https://github.com/alexcyber/secure-chat',
+    slug: 'secure-chat',
   },
   {
-    title: 'Coolify Deployments',
+    title: 'Vuln Notes',
     description:
-      'VSCode extension to track and deploy your Coolify applications.',
-    logo: '/logos/coolify.svg',
-    link: 'https://github.com/itsnitinr/coolify-vscode-extension',
-    slug: 'coolify-vscode-extension',
+      'A collection of write-ups documenting vulnerability research and CTF solutions.',
+    logo: '/logos/markdown_icon.svg',
+    link: 'https://github.com/alexcyber/vuln-notes',
+    slug: 'vuln-notes',
+  },
+  {
+    title: 'Recon Scanner',
+    description:
+      'Automated reconnaissance tool for discovering subdomains and open ports.',
+    logo: '/logos/json_icon.svg',
+    link: 'https://github.com/alexcyber/recon-scanner',
+    slug: 'recon-scanner',
   },
 ];

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -17,7 +17,7 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <Layout>
-      <Head title={`Nitin Ranganath | ${pageProps.title}`} />
+      <Head title={`Alex Cyber | ${pageProps.title}`} />
       <Component {...pageProps} />
     </Layout>
   );

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -4,54 +4,54 @@ const AboutPage = () => {
   return (
     <div className={styles.container}>
       <div className={styles.content}>
-        <h1 className={styles.title}>Nitin Ranganath</h1>
-        <div className={styles.subtitle}>Software Engineer</div>
+        <h1 className={styles.title}>Alex Cyber</h1>
+        <div className={styles.subtitle}>Cybersecurity Student</div>
 
         <div className={styles.aboutContent}>
           <section className={styles.section}>
             <p className={styles.paragraph}>
-              Hey! I&apos;m a software engineer from Mumbai, India. I primarily
-              work with JavaScript / TypeScript and the React ecosystem.
+              Hello! I&apos;m a cybersecurity student passionate about network
+              security, penetration testing and digital forensics. I enjoy
+              exploring how things work under the hood and securing them.
             </p>
             <p className={styles.paragraph}>
-              I&apos;m focused on frontend development with React, but
-              you&apos;ll also find me working with Node.js, MongoDB and Express
-              while building the backend for my personal projects.
+              My studies revolve around securing web applications and building
+              tools that help detect vulnerabilities. I love learning new
+              security techniques and applying them in personal projects.
             </p>
           </section>
 
           <section className={styles.section}>
             <h2 className={styles.sectionTitle}>Experience</h2>
             <p className={styles.paragraph}>
-              Currently at <span className={styles.highlight}>Tessact</span> as
-              Software Engineer 2, working with a lean team of 4 frontend
-              engineers to build a next-gen video creation suite for the people
-              of video.
+              I&apos;m currently pursuing a degree in cybersecurity and
+              participating in my university&apos;s security club. I often take
+              part in Capture The Flag competitions and collaborate with peers
+              on security research projects.
             </p>
             <p className={styles.paragraph}>
-              I&apos;ve been leading the development efforts for bringing
-              collaborative video reviewing and editing to the platform. I also
-              maintain our in-house component library, icon library and website.
+              Recently, I completed an internship focused on vulnerability
+              assessment where I helped audit web applications and improve their
+              overall security posture.
             </p>
           </section>
 
           <section className={styles.section}>
             <h2 className={styles.sectionTitle}>Writing</h2>
             <p className={styles.paragraph}>
-              I&apos;ve had the pleasure of writing for some amazing
-              publications like{' '}
-              <span className={styles.highlight}>100ms Blog</span>,{' '}
-              <span className={styles.highlight}>LogRocket Blog</span>,{' '}
-              <span className={styles.highlight}>DEV.to</span> and more as a
-              freelance technical author.
+              I enjoy sharing write-ups on{' '}
+              <span className={styles.highlight}>DEV.to</span> and my personal
+              blog about the latest security tools and techniques I&apos;ve been
+              experimenting with.
             </p>
           </section>
 
           <section className={styles.section}>
             <h2 className={styles.sectionTitle}>Beyond Code</h2>
             <p className={styles.paragraph}>
-              Aside from programming and writing, I like to read a good
-              dystopian novel, listen to calm piano music or just laze around.
+              When I&apos;m not digging into security concepts, you&apos;ll find me
+              tinkering with retro hardware or enjoying a session of
+              competitive CTFs with friends.
             </p>
           </section>
         </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,9 +14,9 @@ export default function HomePage() {
       type: 'variable',
     },
     { code: '  const developerInfo = {', type: 'variable' },
-    { code: "    name: 'Nitin Ranganath',", type: 'array-item' },
-    { code: "    role: 'Full Stack Developer',", type: 'array-item' },
-    { code: "    bio: 'Building modern web experiences'", type: 'array-item' },
+    { code: "    name: 'Alex Cyber',", type: 'array-item' },
+    { code: "    role: 'Cybersecurity Student',", type: 'array-item' },
+    { code: "    bio: 'Exploring the world of security and hacking'", type: 'array-item' },
     { code: '  };', type: 'array-end' },
     { code: '', type: 'blank' },
     { code: '  useEffect(() => {', type: 'nested-function' },
@@ -91,14 +91,14 @@ export default function HomePage() {
 
         <div className={styles.infoSection}>
           <h1 className={styles.developerName}>
-            Nitin <span className={styles.accentText}>Ranganath</span>
+            Alex <span className={styles.accentText}>Cyber</span>
           </h1>
 
-          <div className={styles.developerRole}>Full Stack Web Developer</div>
+          <div className={styles.developerRole}>Cybersecurity Student</div>
 
           <p className={styles.bio}>
-            I build elegant, responsive web applications with modern
-            technologies. Focused on clean code and intuitive user experiences.
+            I&apos;m passionate about ethical hacking and building tools that
+            strengthen the security of modern applications.
           </p>
 
           <div className={styles.actionLinks}>

--- a/styles/Layout.module.css
+++ b/styles/Layout.module.css
@@ -9,7 +9,7 @@
 .content {
   padding: 2rem;
   color: var(--text-color);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: inherit;
   flex: 1;
   height: 85vh;
   overflow-y: auto;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,5 +1,10 @@
 @import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400&display=swap');
 
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
+    sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+}
+
 *,
 *::before,
 *::after {

--- a/styles/themes.css
+++ b/styles/themes.css
@@ -1,27 +1,27 @@
 /* GitHub Dark */
 :root {
-  --main-bg: #24292e;
-  --bg-text: rgba(56, 58, 61, 0.35);
-  --text-color: #efefef;
-  --accent-color: #f9826c;
-  --titlebar-bg: #1f2428;
-  --sidebar-bg: #24292e;
-  --sidebar-hover-bg: #1f2428;
-  --explorer-bg: #1f2428;
-  --explorer-hover-bg: #24292e;
-  --explorer-border: #161a1d;
-  --tabs-bg: #1f2428;
-  --tab-bg: #1f2428;
-  --tab-active-bg: #24292e;
-  --tab-border: #24292e;
-  --bottombar-bg: #24292e;
-  --bottombar-border: #1b1f23;
-  --button-bg: #176f2c;
-  --button-text: #dcffe4;
-  --bottombar-hover-bg: #4f4f52;
-  --scrollbar-track-bg: #24292e;
-  --scrollbar-thumb-bg: #333536;
-  --article-bg: #1f2428;
+  --main-bg: #0d1117;
+  --bg-text: rgba(22, 27, 34, 0.85);
+  --text-color: #c9d1d9;
+  --accent-color: #2f81f7;
+  --titlebar-bg: #161b22;
+  --sidebar-bg: #0d1117;
+  --sidebar-hover-bg: #161b22;
+  --explorer-bg: #0d1117;
+  --explorer-hover-bg: #161b22;
+  --explorer-border: #30363d;
+  --tabs-bg: #161b22;
+  --tab-bg: #0d1117;
+  --tab-active-bg: #161b22;
+  --tab-border: #30363d;
+  --bottombar-bg: #0d1117;
+  --bottombar-border: #30363d;
+  --button-bg: #238636;
+  --button-text: #ffffff;
+  --bottombar-hover-bg: #21262d;
+  --scrollbar-track-bg: #0d1117;
+  --scrollbar-thumb-bg: #30363d;
+  --article-bg: #161b22;
 }
 
 /* Dracula */


### PR DESCRIPTION
## Summary
- switch default colors to GitHub dark palette
- use system fonts and inherit them in layout
- update homepage and about page for "Alex Cyber"
- customize contact info and cybersecurity project list
- tweak page titles and README description

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840431308b483249bc382413d8b2c1e